### PR TITLE
Remove updating of name and image of connected user

### DIFF
--- a/social-messenger/src/App.js
+++ b/social-messenger/src/App.js
@@ -34,7 +34,7 @@ const sort = {
 };
 
 const chatClient = StreamChat.getInstance(apiKey);
-chatClient.connectUser({ id: user, name: user, image: getRandomImage() }, userToken);
+chatClient.connectUser({ id: user }, userToken);
 
 const App = () => {
   const [isCreating, setIsCreating] = useState(false);


### PR DESCRIPTION
This messes up the users where a valid name/image is already present. A better fix would be to provide these values only if they're missing.