### PR TITLE
fix: prevent message actions from jiggling

### DIFF
--- a/social-messenger-ts/package.json
+++ b/social-messenger-ts/package.json
@@ -5,19 +5,19 @@
   "dependencies": {
     "@stream-io/stream-chat-css": "^2.10.0",
     "lodash.debounce": "^4.0.8",
-    "react": "^18.1.0",
-    "react-dom": "^18.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-file-utils": "^1.1.12",
     "stream-chat": "^6.6.0",
-    "stream-chat-react": "^9.1.2"
+    "stream-chat-react": "^9.1.3"
   },
   "devDependencies": {
     "@types/jest": "^27.5.2",
     "@types/lodash.debounce": "^4.0.7",
-    "@types/react": "^18.0.12",
+    "@types/react": "^18.0.14",
     "@types/react-dom": "^18.0.5",
     "react-scripts": "^5.0.1",
-    "typescript": "^4.7.3"
+    "typescript": "^4.7.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/social-messenger-ts/src/components/CustomMessage/CustomMessage.css
+++ b/social-messenger-ts/src/components/CustomMessage/CustomMessage.css
@@ -18,6 +18,10 @@
   font-weight: 500;
 }
 
+.str-chat__message-simple__actions__action--options button {
+  display: flex;
+}
+
 /* EDIT MESSAGE */
 
 .str-chat__modal.str-chat__modal--open {
@@ -151,28 +155,7 @@ span.react-images__footer__count.react-images__footer__count--isModal {
 }
 
 @media screen and (max-width: 640px) {
-  /* REACTIONS */
-
-  .str-chat__message-simple__actions__action--thread, .str-chat__message-simple__actions__action--reactions {
-    display: flex;
-  }
-
-  .str-chat__message-simple__actions__action--options {
-    display: flex;
-  }
-
-  .str-chat__message--me .str-chat__message-inner > .str-chat__message-simple__actions, .str-chat__message-simple--me .str-chat__message-inner > .str-chat__message-simple__actions {
-    position: unset;
-    margin-bottom: 6px;
-  }
-
-  .str-chat__message-inner > .str-chat__message-simple__actions, .str-chat__message-simple-inner > .str-chat__message-simple__actions {
-    position: unset;
-    margin-bottom: 6px;
-  }
-
   /* EDIT MESSAGE */
-
   .str-chat__modal.str-chat__modal--open {
     padding-top: 200px;
   }
@@ -189,4 +172,15 @@ span.react-images__footer__count.react-images__footer__count--isModal {
   .str-chat__modal__close-button {
     left: 75vw;
   }
+}
+
+.str-chat__message-simple:hover .str-chat__message-simple__actions__action--thread,
+.str-chat__message-simple:hover .str-chat__message-simple__actions__action--reactions,
+.str-chat__message-simple:hover .str-chat__message-simple__actions__action--options {
+  /*
+   * There is a rule which hides all actions on hover for screens < 960px wide.
+   * Here we override that behavior by explicitly enabling hover for all screen sizes.
+   * See: https://github.com/GetStream/stream-chat-react/issues/1641
+   */
+  display: flex;
 }

--- a/social-messenger-ts/src/hooks/useChecklist.ts
+++ b/social-messenger-ts/src/hooks/useChecklist.ts
@@ -7,6 +7,7 @@ const notifyParent = (parent: string) => (message: any) => {
 };
 
 const YOUTUBE_LINK = 'https://youtu.be/Ujvy-DEA-UM';
+const YOUTUBE_LINK_RE = /^(http(s)?:\/\/)?(youtu.be\/Ujvy-DEA-UM\/?)$/;
 
 // We have to keep this task list up-to-date with the website's checklist
 const [REACT_TO_MESSAGE, RUN_GIPHY, SEND_YOUTUBE, DRAG_DROP, START_THREAD, SEND_MESSAGE] = [
@@ -35,14 +36,16 @@ export const useChecklist = (chatClient: StreamChat | null, targetOrigin: string
             break;
           }
           if (message && message.attachments && message.attachments.length) {
+            const [attachment] = message.attachments;
             if (
-              message.attachments[0].type === 'video' &&
-              message.attachments[0].og_scrape_url === YOUTUBE_LINK
+              attachment.type === 'video' &&
+              (attachment.og_scrape_url === YOUTUBE_LINK ||
+                YOUTUBE_LINK_RE.test(attachment.og_scrape_url as string))
             ) {
               notify(SEND_YOUTUBE);
               break;
             }
-            if (message.attachments[0].type === 'image') {
+            if (attachment.type === 'image') {
               notify(DRAG_DROP);
               break;
             }

--- a/social-messenger-ts/yarn.lock
+++ b/social-messenger-ts/yarn.lock
@@ -2829,10 +2829,10 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/react@^18.0.12":
-  version "18.0.12"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.12.tgz#cdaa209d0a542b3fcf69cf31a03976ec4cdd8840"
-  integrity sha512-duF1OTASSBQtcigUvhuiTB1Ya3OvSy+xORCiEf20H0P0lzx+/KeVsA99U5UjLXSbyo1DRJDlLKqTeM1ngosqtg==
+"@types/react@^18.0.14":
+  version "18.0.14"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.14.tgz#e016616ffff51dba01b04945610fe3671fdbe06d"
+  integrity sha512-x4gGuASSiWmo0xjDLpm5mPb52syZHJx02VKbqUKdLmKtAwIh63XClGsiTI1K6DO5q7ox4xAsQrU+Gl3+gGXF9Q==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -8641,13 +8641,13 @@ react-dev-utils@^12.0.1:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
-react-dom@^18.1.0:
-  version "18.1.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.1.0.tgz#7f6dd84b706408adde05e1df575b3a024d7e8a2f"
-  integrity sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==
+react-dom@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
+  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
   dependencies:
     loose-envify "^1.1.0"
-    scheduler "^0.22.0"
+    scheduler "^0.23.0"
 
 react-dropzone@^12.0.5:
   version "12.1.0"
@@ -8711,10 +8711,10 @@ react-markdown@^5.0.3:
     unist-util-visit "^2.0.0"
     xtend "^4.0.1"
 
-react-player@^2.7.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/react-player/-/react-player-2.10.0.tgz#bd3e0f10ae756cc644efb14177a515d455d97e20"
-  integrity sha512-PccIqea9nxSHAdai6R+Yj9lp6tb2lyXWbaF6YVHi5uO4FiXYMKKr9rMXJrivwV5vXwQa65rYKBmwebsBmRTT3w==
+react-player@^2.10.1:
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/react-player/-/react-player-2.10.1.tgz#f2ee3ec31393d7042f727737545414b951ffc7e4"
+  integrity sha512-ova0jY1Y1lqLYxOehkzbNEju4rFXYVkr5rdGD71nsiG4UKPzRXQPTd3xjoDssheoMNjZ51mjT5ysTrdQ2tEvsg==
   dependencies:
     deepmerge "^4.0.0"
     load-script "^1.0.0"
@@ -8799,10 +8799,10 @@ react-virtuoso@^2.10.2:
     "@virtuoso.dev/react-urx" "^0.2.12"
     "@virtuoso.dev/urx" "^0.2.12"
 
-react@^18.1.0:
-  version "18.1.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.1.0.tgz#6f8620382decb17fdc5cc223a115e2adbf104890"
-  integrity sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==
+react@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
 
@@ -9129,10 +9129,10 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.22.0.tgz#83a5d63594edf074add9a7198b1bae76c3db01b8"
-  integrity sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==
+scheduler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
+  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
   dependencies:
     loose-envify "^1.1.0"
 
@@ -9466,10 +9466,10 @@ statuses@2.0.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-stream-chat-react@^9.1.2:
-  version "9.1.2"
-  resolved "https://registry.yarnpkg.com/stream-chat-react/-/stream-chat-react-9.1.2.tgz#0ee2df02553bf10c0aeb45888d8300144b93996b"
-  integrity sha512-U3HghQWyIHjHuJjdQ7RucqNh72I9jXYg0YfNeuQ1QRkJyI+NG7Em+Q/K+YscVrVND/a79xiLjpi1Fj9ZKJBNFA==
+stream-chat-react@^9.1.3:
+  version "9.1.3"
+  resolved "https://registry.yarnpkg.com/stream-chat-react/-/stream-chat-react-9.1.3.tgz#02d914496ac536a4e546fb488e093c7b32f4aa3b"
+  integrity sha512-Zi9xFIK9eSV4aC1/rfodUUJd4/8fgm8eC2uX8eBgmHOx5kX+Qg9lV0niXQnGzQHIyORrZ1mprB4as6ymQC2Ljg==
   dependencies:
     "@braintree/sanitize-url" "6.0.0"
     "@juggle/resize-observer" "^3.3.1"
@@ -9493,7 +9493,7 @@ stream-chat-react@^9.1.2:
     react-image-gallery "^1.2.7"
     react-is "^18.1.0"
     react-markdown "^5.0.3"
-    react-player "^2.7.0"
+    react-player "^2.10.1"
     react-textarea-autosize "^8.3.0"
     react-virtuoso "^2.10.2"
     textarea-caret "^3.1.0"
@@ -9993,10 +9993,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.7.3:
-  version "4.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.3.tgz#8364b502d5257b540f9de4c40be84c98e23a129d"
-  integrity sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==
+typescript@^4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unbox-primitive@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
**Goal**

This PR aims to fix a few problems in the social messenger demo.
1. On the [website](https://getstream.io/chat/demos/messaging/), the demo checklist didn't update correctly upon sharing the predefined youtube video
2. On small screens, when hovering the message actions, they were entering an infinite show/hide loop making the whole UI jump (see the attachments)

<details>
<summary>Before</summary>
https://user-images.githubusercontent.com/843172/174631266-407ffa31-a137-414c-bee6-f8289b747915.mov
</details>

<details>
<summary>After</summary>
https://user-images.githubusercontent.com/843172/174632758-7c64cf51-af21-4e29-8fe6-5df8744a57eb.mov
</details>

**Implementation details**

- Message actions now render left/right of the message (before: they were rendered above the message)
- Message actions now show up on hover regardless of device screen size (devices without mouse support can tap on the message)