### PR TITLE
chore(ci): upgrade GitHub actions versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,9 +16,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
 
@@ -28,7 +28,7 @@ jobs:
         run: yarn build:js:public
 
       - name: Upload Pages Artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: docs/
           name: gh-pages-artifact
@@ -48,6 +48,6 @@ jobs:
     steps:
       - name: Deploy to Github Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4
         with:
           artifact_name: gh-pages-artifact


### PR DESCRIPTION
## Goal

Deploy the apps with the up-to-date GH actions.

See the error on which the deploy fails:

https://github.com/GetStream/website-react-examples/actions/runs/15632086250/job/44038611067

GitHub article:

https://github.blog/changelog/2024-12-05-deprecation-notice-github-pages-actions-to-require-artifacts-actions-v4-on-github-com/

<img width="907" alt="image" src="https://github.com/user-attachments/assets/ffb1d583-576c-451b-a2ad-3d87d182406c" />